### PR TITLE
Sets window.location query params from data attributes [#128524405]

### DIFF
--- a/app/assets/javascripts/admin/spree_product_grid_sort.coffee
+++ b/app/assets/javascripts/admin/spree_product_grid_sort.coffee
@@ -17,13 +17,30 @@
     @grid = $(".classification-grid ul").sortable(options)
     $("#admin_save_grid_order").on "click", @saveGridOrder
 
+  # Returns all but the url property of a data object returned by jQuery's data() function.
+  filterData = (data) ->
+    filtered = new Object()
+    for own key, value of data
+      filtered[key] = data[key] unless key == "url"
+    filtered
+
+  # All HTML5 data attributes except url will be turned into query params
+  # on the window.location URL.
   taxon_navigate: (e) ->
     menu            = $("#taxon_menu")
-    window.location = menu.attr("data-url") + "/?taxon_id=" + menu.val()
+    data            = menu.data()
+    filtered_data   = filterData(data)
+    filtered_data['taxon_id'] = menu.val()
+    window.location = data.url + "?" + $.param(filtered_data)
 
+  # All HTML5 data attributes except url will be turned into query params
+  # on the window.location URL.
   store_navigate: (e) ->
     menu            = $("#store_menu")
-    window.location = menu.attr("data-url") + "/?store_id=" + menu.val()
+    data            = menu.data()
+    filtered_data   = filterData(data)
+    filtered_data['store_id'] = menu.val()
+    window.location = data.url + "?" + $.param(filtered_data)
 
   extractGridOrder: ($w, wgd) =>
     pos = ((wgd.row-1)*6) + wgd.col
@@ -48,7 +65,6 @@
         location.reload()
       error: (response) =>
         show_flash 'error', response.responseJSON?.error || 'Grid saving failed!'
-
 
 $(document).ready ->
   new ReorderPage()

--- a/app/helpers/spree/admin/grid_orders_helper.rb
+++ b/app/helpers/spree/admin/grid_orders_helper.rb
@@ -10,10 +10,10 @@ module Spree::Admin::GridOrdersHelper
     select_tag :grid_id, options, opt
   end
 
-  def retail_store_dropdown_menu(stores, taxon)
-    options = options_from_collection_for_select stores, :id, :pretty_name, params['store_id']
-    opt_with_default = '<option value="">All</option>'.html_safe + options
+  def retail_store_dropdown_menu(stores, taxon, options={})
+    option_tags = options_from_collection_for_select stores, :id, :pretty_name, params['store_id']
+    opt_with_default = '<option value="">All</option>'.html_safe + option_tags
 
-    select_tag :store_menu, opt_with_default, 'data-url' => admin_retail_grid_orders_url
+    select_tag :store_menu, opt_with_default, options
   end
 end


### PR DESCRIPTION
The taxon_navigate method changes the window.location on change, but
the selection needs to be dependent on the store_id selected by the
store_navigate method. The two methods clashed and clobbered each
other's query params. This change allows the user of the gem to specify
the window.location query params as HTML5 attributes. The attributes are
converted to query params by the gem and the query params are appended
to the window.location URL.

[Reformation PR 712](https://github.com/Reformation/reformation/pull/712) depends on this change.